### PR TITLE
Modify next.config.js to run tauri build

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -3,6 +3,9 @@
  */
 const nextConfig = {
   output: "export",
+  images: {
+    unoptimized: true,
+  },
   reactStrictMode: false,
 };
 


### PR DESCRIPTION
- 現在のmain branchの状態だと`npm run build` (tauri build)で以下のエラーが発生した
- これを解消するために image:~ の部分を追加した
　　- 追加したことでbuildが走るようにはなったが、他の部分に影響が出るかは分からない(現段階での見た目上は問題なさそう)
```
> Image Optimization using the default loader is not compatible with export.
  Possible solutions:
    - Use `next start` to run a server, which includes the Image Optimization API.
    - Configure `images.unoptimized = true` in `next.config.js` to disable the Image Optimization API.
  Read more: https://nextjs.org/docs/messages/export-image-api
   Finalizing page optimization  .       Error beforeBuildCommand `npm run next-build` failed with exit code 1
```