### PR TITLE
Bugfix Preventing Disconnection on Chain Edge Removal

### DIFF
--- a/desktop/src/components/circuit/hooks/use-delete-nodes-edges.ts
+++ b/desktop/src/components/circuit/hooks/use-delete-nodes-edges.ts
@@ -61,7 +61,7 @@ export const useDeleteNodesEdges = () => {
       const { getNodes, getEdges, setNodes } = reactflow;
 
       const allNodes = getNodes();
-      const allEdges = getEdges();
+      const allEdges = getEdges().filter((edge) => edge.type === "custom"); // Ignore annotation edges
 
       const newNodes = produce(allNodes, (draft) => {
         disconnectHandles(draft, deletedEdges);


### PR DESCRIPTION
This issue was caused by counting annotation edges as actual edges. This fix ensures that parent nodes are properly disconnected when those edges are removed.